### PR TITLE
Small update in quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ async def on_balance_update(
 ) -> None:
     holder, _ = await models.Holder.get_or_create(address=address)
     holder.balance += balance_update
-    holder.turnover += abs(balance_update)
     holder.tx_count += 1
     holder.last_seen = timestamp
     assert holder.balance >= 0, address

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ class Holder(Model):
     balance = fields.DecimalField(decimal_places=8, max_digits=20, default=0)
     volume = fields.DecimalField(decimal_places=8, max_digits=20, default=0)
     tx_count = fields.BigIntField(default=0)
-    last_seen = fields.DateTimeField(null=True)
+    last_seen = fields.DatetimeField(null=True)
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
It seems that this shouldn't be capitalized like this. https://tortoise-orm.readthedocs.io/en/latest/fields.html#tortoise.fields.data.DatetimeField

Maybe they updated it over time? Dipdup installs v0.17.5 for me.

Also, turnover isn't defined on the quickstart model, so updating it won't work (AFAIK, my IDE gave me this warning).